### PR TITLE
US9: Admin Group Allocations backend

### DIFF
--- a/controllers/admin/projects/group_allocations/group_allocations.controller.js
+++ b/controllers/admin/projects/group_allocations/group_allocations.controller.js
@@ -1,0 +1,73 @@
+const model = require('../../../../models/index')
+
+// Return all GroupAllocations of this project
+exports.findAll = (req, res) => {
+  model.Group.findAll({ where: { project_id: req.params.project_id }})
+  .then(groups => {
+    const group_ids = groups.map(group => group.id);
+
+    model.GroupAllocation.findAll({ where: { group_id: group_ids }})
+      .then(group_allocations => {
+        res.send(group_allocations);
+      })
+      .catch(err => {
+        res.status(500).send({
+          message:
+            err.message || `Some error occurred while retrieving Group Allocations for Project ${req.params.project_id}`
+        });
+      });
+  })
+  .catch(err => {
+    res.status(500).send({message: err.message || `Error occurred retrieving Groups for Project ${req.params.project_id}`});
+  })
+}
+
+// Create a Group Allocation associated to this Project
+exports.createOne = (req, res) => {
+  if (req.body.group_id && req.body.external_id) {
+    model.User.findOne({ where: { external_id: req.body.external_id }}).then(user => {
+      model.Group.findOne({ where: { id: req.body.group_id }})
+        .then(group => {
+          model.GroupAllocation.create({ user_id: user.id, group_id: group.id})
+            .then(group_allocation => res.send(group_allocation))
+            .catch(err => res.status(500).send({ message: err.message || 'Cannot create Group Allocation' }))
+        })
+        .catch(err => {
+          res.status(500).send({ message: err.message || 'Cannot find Group' });
+        })
+    }).catch(err => {
+      res.status(500).send({ message: err.message || 'Cannot find User/Student' });
+    })
+  } else {
+    res.status(400).send({ message: 'The request does not contain the necessary parameters' });
+  }
+}
+
+// Delete a single Group Allocation
+exports.deleteOne = (req, res) => {
+  if (req.body.group_id && req.body.external_id) {
+
+    model.User.findOne({ where: { external_id: req.body.external_id }})
+    .then(user => {
+      model.GroupAllocation.findOne({ 
+        where: { group_id: req.body.group_id, user_id: user.id }
+      })
+        .then(group_allocation => {
+          if(group_allocation) {
+            group_allocation.destroy();
+            res.status(200).send({ message: 'Deleted!'});
+          } else {
+            res.status(200).send({ message: 'Already deleted!'});
+          }
+        })
+        .catch(err => {
+          res.status(500).send({ message: err.message || "Could not find GroupAllocation to delete" });
+        })
+    })
+    .catch(err => {
+      res.status(500).send({ message: err.message || "Could not find User" });
+    })
+  } else {
+    res.status(400).send({ message: 'The request does not contain the necessary parameters' });
+  }
+}

--- a/controllers/admin/projects/groups/groups.controller.js
+++ b/controllers/admin/projects/groups/groups.controller.js
@@ -1,8 +1,8 @@
-const model = require('../../../models/index')
+const model = require('../../../../models/index')
 
-// Return all groups
+// Return all Groups associated to this Project
 exports.findAll = (req, res) => {
-  model.Group.findAll()
+  model.Group.findAll({ where: { project_id: req.params.project_id }})
     .then(groups => {
       res.send(groups);
     })
@@ -14,12 +14,12 @@ exports.findAll = (req, res) => {
     });
 }
 
-// Return information about a single group
+// Return a single Group
 exports.findOne = (req, res) => {
-  model.Group.findByPk(req.params.id)
+  model.Group.findOne({ where: { project_id: req.params.project_id, id: req.params.id }})
   .then(group => {
     if (group == null) {
-      res.status(404).send({ message: `Group with id: ${req.params.id} does not exist` });
+      res.status(404).send({ message: `Group ${req.params.id} is not associated to Project ${req.params.project_id}` });
     } else {
       res.send(group);
     }

--- a/routes/admin/projects/group_allocations/group_allocations.routes.js
+++ b/routes/admin/projects/group_allocations/group_allocations.routes.js
@@ -1,0 +1,19 @@
+module.exports = app => {
+  const adminGroupAllocationsController = require('../../../../controllers/admin/projects/group_allocations/group_allocations.controller')
+  const adminGroupAllocationsRouter = require('express').Router({ mergeParams: true });
+
+  // Ensure user is logged in for all requests handled by this router
+  const admin_auth = require('../../../../middleware/admin_auth');
+
+  // Get all Group Allocations for this Project
+  adminGroupAllocationsRouter.get('/', admin_auth, adminGroupAllocationsController.findAll)
+
+  // Create a Group Allocation under this Project
+  adminGroupAllocationsRouter.post('/', admin_auth, adminGroupAllocationsController.createOne);
+
+  // Delete a Group Allocation under this Project
+  adminGroupAllocationsRouter.delete('/', admin_auth, adminGroupAllocationsController.deleteOne);
+
+  // Tell express to route all requests directed to /api/admin/users to the router defined in this file
+  app.use('/api/admin/projects/:project_id/group_allocations', adminGroupAllocationsRouter);
+}

--- a/routes/admin/projects/groups/groups.routes.js
+++ b/routes/admin/projects/groups/groups.routes.js
@@ -1,9 +1,9 @@
 module.exports = app => {
-  const adminGroupsController = require('../../../controllers/admin/groups/groups.controller')
+  const adminGroupsController = require('../../../../controllers/admin/projects/groups/groups.controller')
   const adminGroupRouter = require('express').Router({ mergeParams: true });
 
   // Ensure user is logged in for all requests handled by this router
-  const admin_auth = require('../../../middleware/admin_auth');
+  const admin_auth = require('../../../../middleware/admin_auth');
 
   // Get all projects for the logged in user
   adminGroupRouter.get('/', admin_auth, adminGroupsController.findAll)
@@ -12,5 +12,5 @@ module.exports = app => {
   adminGroupRouter.get('/:id', admin_auth, adminGroupsController.findOne);
 
   // Tell express to route all requests directed to /api/admin/users to the router defined in this file
-  app.use('/api/admin/groups', adminGroupRouter);
+  app.use('/api/admin/projects/:project_id/groups', adminGroupRouter);
 }

--- a/server.js
+++ b/server.js
@@ -32,8 +32,9 @@ store.sync();
 require('./routes/auth/auth.routes')(app);
 
 // Admin routes
-require('./routes/admin/groups/groups.routes')(app);
 require('./routes/admin/projects/projects.routes')(app);
+require('./routes/admin/projects/groups/groups.routes')(app);
+require('./routes/admin/projects/group_allocations/group_allocations.routes')(app);
 require('./routes/admin/users/users.routes')(app);
 
 // Student Routes


### PR DESCRIPTION
## What is this change doing?

- Rearrange Admin groups routes to make more sense
- Provide endpoints to allow Admin to view, create and delete Group Allocations

## Why is it needed?

Admin needs to be able to organise Groups in a Project

## Where should the reviewer start?

server.js
routes/admin/projects/group_allocations/group_allocations.routes.js 
then remaining changes 

## How can these changes be manually tested?

See Postman

## What user story does this PR relate to? (include link)

US9
