### PR TITLE
Fix session persistence in Chrome (and any other browser)

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-// import logo from './logo.svg';
+// import logo from './logo.svg'; // commented out because it's not being used
 import './App.css';
 import css from "./Login.module.css"
 
@@ -20,8 +20,8 @@ class App extends Component {
     }
   }
 
-  HandleLogin()
-  {
+  handleLogin() {
+    // external_id and password should be pulled from the input fields
     const jsonString = JSON.stringify({ external_id: 'something', password: 'somePassword' });
 
     fetch('http://localhost:6060/api/users/auth', {
@@ -33,20 +33,8 @@ class App extends Component {
       .then(response => response.json())
       .then(j => {
         console.log(j)
-        // this.redirect(j.user_type)
+        this.redirect(j.user_type)
       })
-  }
-
-  HandleProjectFetch()
-  {
-    fetch('http://localhost:6060/api/student/projects', {
-          credentials: 'include',
-          headers: { 'Content-Type': 'application/json' }
-        })
-          .then(response => response.json())
-          .then(j => {
-              console.log(j)
-          })
   }
 
 render() {
@@ -63,8 +51,7 @@ render() {
 
           <p className={css.usernameandpassword}><br/>Password: </p>
           <input className={css.input} type="password"></input>
-          <button className={css.signinbtn} onClick={()=>this.HandleLogin()}>Sign in</button>
-          <button className={css.signinbtn} onClick={()=>this.HandleProjectFetch()}>Get Projects</button>
+          <button className={css.signinbtn} onClick={()=>this.handleLogin()}>Sign in</button>
         </div>
         {/*I just do not change your code so make it as commit
          <div>

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -32,7 +32,16 @@ class App extends Component {
       .then(response => response.json())
       .then(j => {
         console.log(j)
-        this.redirect(j.user_type)
+        // this.redirect(j.user_type)
+
+        // fetch('http://localhost:6060/api/student/projects', {
+        //   credentials: 'include',
+        //   headers: { 'Content-Type': 'application/json' }
+        // })
+        //   .then(response => response.json())
+        //   .then(j => {
+        //       console.log(j)
+        //   })
       })
   }
 

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import logo from './logo.svg';
+// import logo from './logo.svg';
 import './App.css';
 import css from "./Login.module.css"
 
@@ -12,10 +12,10 @@ class App extends Component {
   };
 
   redirect(user_type) {
-    if(user_type == 1) {
+    if(user_type === 1) {
       window.location.href="/student/home"
     }
-    else if(user_type == 2) {
+    else if(user_type === 2) {
       window.location.href="/admin/home"
     }
   }
@@ -27,32 +27,34 @@ class App extends Component {
     fetch('http://localhost:6060/api/users/auth', {
       method: 'post',
       headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
       body: jsonString
     })
       .then(response => response.json())
       .then(j => {
         console.log(j)
         // this.redirect(j.user_type)
-
-        // fetch('http://localhost:6060/api/student/projects', {
-        //   credentials: 'include',
-        //   headers: { 'Content-Type': 'application/json' }
-        // })
-        //   .then(response => response.json())
-        //   .then(j => {
-        //       console.log(j)
-        //   })
       })
+  }
+
+  HandleProjectFetch()
+  {
+    fetch('http://localhost:6060/api/student/projects', {
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' }
+        })
+          .then(response => response.json())
+          .then(j => {
+              console.log(j)
+          })
   }
 
 render() {
     return (
-      <body>
+      <React.Fragment>
         <div>
-          <headers>
-            <h1 className={css.head}>Group Arrangement</h1>               
-          </headers>   
-        </div>   
+          <h1 className={css.head}>Group Arrangement</h1>
+        </div>
 
         <div>
           <p className={css.subtitle}>Sign in</p>
@@ -62,6 +64,7 @@ render() {
           <p className={css.usernameandpassword}><br/>Password: </p>
           <input className={css.input} type="password"></input>
           <button className={css.signinbtn} onClick={()=>this.HandleLogin()}>Sign in</button>
+          <button className={css.signinbtn} onClick={()=>this.HandleProjectFetch()}>Get Projects</button>
         </div>
         {/*I just do not change your code so make it as commit
          <div>
@@ -70,7 +73,7 @@ render() {
           ))}
         </div>
         <p>Number of users: {this.state.userList.length}</p>*/} 
-        </body>   
+      </React.Fragment>
     );
   }
 }

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -22,8 +22,7 @@ class App extends Component {
 
   HandleLogin()
   {
-    console.log("hi");
-    const jsonString = JSON.stringify({ external_id: 'something5', password: 'somePassword' });
+    const jsonString = JSON.stringify({ external_id: 'something', password: 'somePassword' });
 
     fetch('http://localhost:6060/api/users/auth', {
       method: 'post',

--- a/client/src/Components/DNDComponents/DragNDrop.js
+++ b/client/src/Components/DNDComponents/DragNDrop.js
@@ -24,7 +24,7 @@ class DragNDrop extends React.Component {
         const start = this.state.columns[source.droppableId];
         const finish = this.state.columns[destination.droppableId];
 
-        if(start == finish) {
+        if(start === finish) {
             const newStudentIds = Array.from(start.studentIds);
             newStudentIds.splice(source.index, 1);
             newStudentIds.splice(destination.index, 0, draggableId);

--- a/client/src/Components/StudentMainMenu.js
+++ b/client/src/Components/StudentMainMenu.js
@@ -29,11 +29,14 @@ class StudentMainMenu extends Component{
     componentDidMount(){
         this._getrandomcolor();
 
-        fetch('http://localhost:6060/api/student/projects')
-            .then(response => response.json())
-            .then(j => {
-                console.log(j)
-            })   
+        fetch('http://localhost:6060/api/student/projects', {
+            credentials: 'include',
+            headers: { 'Content-Type': 'application/json' }
+        })
+        .then(response => response.json())
+        .then(j => {
+            console.log(j)
+        })
     }
 
     _getrandomcolor(){

--- a/client/src/Components/StudentMainMenu.js
+++ b/client/src/Components/StudentMainMenu.js
@@ -28,6 +28,12 @@ class StudentMainMenu extends Component{
 
     componentDidMount(){
         this._getrandomcolor();
+
+        fetch('http://localhost:6060/api/student/projects')
+            .then(response => response.json())
+            .then(j => {
+                console.log(j)
+            })   
     }
 
     _getrandomcolor(){

--- a/client/src/Components/StudentProfile.js
+++ b/client/src/Components/StudentProfile.js
@@ -20,12 +20,16 @@ class StudentProfile extends Component{
       };
 
     async componentDidMount() {
-         const url = 'http://localhost:6060/api/student/profile';
-         const response = await fetch(url);
-         const data = await response.json();
-         console.log(data);
-         // this.setState({student: data.users[1]});
-         }
+        fetch('http://localhost:6060/api/student/profile', {
+            credentials: 'include',
+            headers: { 'Content-Type': 'application/json' }
+        })
+            .then(response => response.json())
+            .then(j => {
+                console.log(j)
+                // this.setState({student: data.users[1]});
+            })
+    }
 
     render() {
         return(

--- a/client/src/Components/StudentProfile.js
+++ b/client/src/Components/StudentProfile.js
@@ -20,9 +20,10 @@ class StudentProfile extends Component{
       };
 
     async componentDidMount() {
-         const url = 'http://localhost:6060/api/users';
+         const url = 'http://localhost:6060/api/student/profile';
          const response = await fetch(url);
          const data = await response.json();
+         console.log(data);
          // this.setState({student: data.users[1]});
          }
 

--- a/controllers/auth/auth.controller.js
+++ b/controllers/auth/auth.controller.js
@@ -9,7 +9,13 @@ exports.login = (request, response) => {
       // If the user with the same external_id is found, check that they password matches
       if (user && bcrypt.compareSync(password, user.encrypted_password)) {
         request.session.external_id = external_id;
-        response.status(200).send({ message: "Signed in!", user_type: user.user_type });
+        request.session.save((err) => {
+          console.log('On authentication');
+	        console.log(request.session.id);
+          console.log(err || request.session);
+
+          response.status(200).send({ message: "Signed in!", user_type: user.user_type });
+        });
       } else {
         response.send({ message: "Incorrect ID and/or Password!" });
       }

--- a/controllers/auth/auth.controller.js
+++ b/controllers/auth/auth.controller.js
@@ -11,11 +11,7 @@ exports.login = (request, response) => {
         request.session.external_id = external_id;
         response.status(200).send({ message: "Signed in!", user_type: user.user_type });
       } else {
-<<<<<<< HEAD
-        response.send({message: "Incorrect ID and/or Password!"});
-=======
         response.send({ message: "Incorrect ID and/or Password!" });
->>>>>>> master
       }
     });
   } else {

--- a/controllers/auth/auth.controller.js
+++ b/controllers/auth/auth.controller.js
@@ -4,26 +4,33 @@ const bcrypt = require("bcryptjs");
 exports.login = (request, response) => {
   let { external_id, password } = request.body;
 
-  if (external_id && password) {
-    model.User.findOne({ where: { external_id: external_id } }).then((user) => {
-      // If the user with the same external_id is found, check that they password matches
-      if (user && bcrypt.compareSync(password, user.encrypted_password)) {
-        request.session.external_id = external_id;
-        request.session.save((err) => {
-          console.log('On authentication');
-	        console.log(request.session.id);
-          console.log(err || request.session);
-
-          response.status(200).send({ message: "Signed in!", user_type: user.user_type });
-        });
-      } else {
-        response.send({ message: "Incorrect ID and/or Password!" });
-      }
-    });
+  // Return early in the user is already logged in
+  if (request.session.external_id) {
+    response.status(200).send({ message: 'You are already logged in' });
   } else {
-    response
-      .status(400)
-      .send({ message: "External user id and password was not provided" });
+
+    // Ensure request contains the right params
+    if (external_id && password) {
+      model.User.findOne({ where: { external_id: external_id } }).then((user) => {
+        // If the user with the same external_id is found, check that they password matches
+        if (user && bcrypt.compareSync(password, user.encrypted_password)) {
+          request.session.external_id = external_id;
+          request.session.save((err) => {
+            console.log('On authentication');
+            console.log(request.session.id);
+            console.log(err || request.session);
+
+            response.status(200).send({ message: "Signed in!", user_type: user.user_type });
+          });
+        } else {
+          response.send({ message: "Incorrect ID and/or Password!" });
+        }
+      });
+    } else {
+      response
+        .status(400)
+        .send({ message: "External user id and password was not provided" });
+    }
   }
 };
 

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -1,10 +1,6 @@
 module.exports = (request, response, next) => {
   // If the user is signed in, then continue with the request
   // If they aren't signed in, response with Unauthorized(401)
-	console.log('In middleware');
-	console.log(request.session.id);
-	console.log(request.session);
-
   if (request.session.external_id) {
 		next();
 	} else {

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -4,6 +4,6 @@ module.exports = (request, response, next) => {
   if (request.session.external_id) {
 		next();
 	} else {
-		response.status(401).send('Sorry, you do not have the permission to do that');
+		response.status(401).send({ message: 'Sorry, you do not have the permission to do that' });
 	}
 };

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -1,6 +1,10 @@
 module.exports = (request, response, next) => {
   // If the user is signed in, then continue with the request
   // If they aren't signed in, response with Unauthorized(401)
+	console.log('In middleware');
+	console.log(request.session.id);
+	console.log(request.session);
+
   if (request.session.external_id) {
 		next();
 	} else {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "bcrypt": "^5.0.1",
     "bcryptjs": "^2.4.3",
     "connect-session-sequelize": "^7.1.1",
-    "cookie-parser": "^1.4.5",
     "cors": "^2.8.5",
     "express-session": "^1.17.1",
     "nodemon": "^2.0.7",

--- a/server.js
+++ b/server.js
@@ -13,10 +13,9 @@ const store = new SequelizeStore({ db: sequelize });
 const app = express();
 const port = process.env.PORT || 6060;
 
-app.enable('trust proxy')
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
-app.use(cors({ origin: "http://localhost:3000", preflightContinue: false, credentials: true })); // https://stackoverflow.com/a/63547498/8186540
+app.use(cors({ origin: "http://localhost:3000", withoutPreflight: true, credentials: true })); // https://stackoverflow.com/a/63547498/8186540
 app.use(session({
   secret: 'someSecret',
   store,
@@ -25,7 +24,7 @@ app.use(session({
   cookie: {
     secure: false,
     maxAge: null,
-    sameSite: "none"
+    sameSite: "lax"
   }
 }));
 

--- a/server.js
+++ b/server.js
@@ -1,7 +1,6 @@
 const express = require('express');
 const session = require('express-session');
 const cors = require('cors');
-var cookieParser = require('cookie-parser');
 
 // Sequelize ORM
 // Typically would be pulled from environment variables
@@ -14,15 +13,20 @@ const store = new SequelizeStore({ db: sequelize });
 const app = express();
 const port = process.env.PORT || 6060;
 
+app.enable('trust proxy')
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
-app.use(cors()); // https://stackoverflow.com/a/63547498/8186540
-app.use(cookieParser());
+app.use(cors({ origin: "http://localhost:3000", preflightContinue: false, credentials: true })); // https://stackoverflow.com/a/63547498/8186540
 app.use(session({
   secret: 'someSecret',
   store,
-  saveUninitialized : true,
-  resave : true
+  saveUninitialized : false,
+  resave : false,
+  cookie: {
+    secure: false,
+    maxAge: null,
+    sameSite: "none"
+  }
 }));
 
 // Keep session store up to date


### PR DESCRIPTION
## What is this change doing?

Ensures the cookie is kept by Chrome (and other browsers) between requests.

## Why is it needed?

The cookie returned to the browser returned upon successful authentication was not being kept by Chrome due to Chrome's dislike of passing cookies over HTTP. If we had chosen to implement HTTPS, this would not really be an issue - however implementing HTTPS has it's own development overheads.

## Where should the reviewer start?

server.js to see the changes to our express session and express cookie configurations

client/src/Components/StudentMainMenu.js to see an example asynchronous query we will be making from the front end. You **MUST** apply the `credentials: true` flag to EACH request which requires authentication. For more details about this, see [the following documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials).

## How can these changes be manually tested?

1) Start the express server and react app by running `yarn dev` in the root directory of this project
2) Open Chrome and navigate to `http://localhost:3000` (or just to the page which is automatically opened by running the command)
3) Click the `Sign in` button and expect to be redirected to the student homepage
4) Open the developer console and expect the request to `http://localhost:3000/api/student/projects` to have succeeded. Ensure the response was **NOT** a `401 Unauthorized`.
5) Go to the Application tab of the developer console in Chrome and expect to see a cookie like the following

![Screen Shot 2021-05-13 at 10 12 20 pm](https://user-images.githubusercontent.com/43333051/118123970-4ee91b00-b438-11eb-8a72-a995fe2791f6.png)

6) Delete the cookie by left clicking then delete and then refresh the page. Expect the request to `projects` to FAIL and be a `401 Unauthorized`
